### PR TITLE
resolve warning: Use of uninitialized value  in addition (+) lib/Test…

### DIFF
--- a/lib/Test/Timer.pm
+++ b/lib/Test/Timer.pm
@@ -165,7 +165,7 @@ sub _benchmark {
     my ( $code, $threshold ) = @_;
 
     my $timestring;
-    my $alarm = $alarm + $threshold;
+    my $alarm = $alarm + ($threshold || 0);
 
     try {
         local $SIG{ALRM} = sub {


### PR DESCRIPTION
during installation perl complaned about uninitialized $threshold

```
t/time_between.t .......... ok
Use of uninitialized value $threshold in addition (+) at /home/palik/.cpanplus/5.18.2/build/Test-Timer-0.12/blib/lib/Test/Timer.pm line 168.
t/time_nok.t .............. ok
Use of uninitialized value $threshold in addition (+) at /home/palik/.cpanplus/5.18.2/build/Test-Timer-0.12/blib/lib/Test/Timer.pm line 168.
```
